### PR TITLE
Use same path as youtube

### DIFF
--- a/src/main/java/me/kavin/piped/ServerLauncher.java
+++ b/src/main/java/me/kavin/piped/ServerLauncher.java
@@ -79,7 +79,7 @@ public class ServerLauncher extends MultithreadedHttpServerLauncher {
             } catch (Exception e) {
                 return getErrorResponse(e);
             }
-        })).map("/channels/:channelId", AsyncServlet.ofBlocking(executor, request -> {
+        })).map("/channel/:channelId", AsyncServlet.ofBlocking(executor, request -> {
             try {
                 return getJsonResponse(
                         ResponseHelper.channelResponse("channel/" + request.getPathParameter("channelId")),
@@ -101,7 +101,7 @@ public class ServerLauncher extends MultithreadedHttpServerLauncher {
             } catch (Exception e) {
                 return getErrorResponse(e);
             }
-        })).map("/nextpage/channels/:channelId", AsyncServlet.ofBlocking(executor, request -> {
+        })).map("/nextpage/channel/:channelId", AsyncServlet.ofBlocking(executor, request -> {
             try {
                 return getJsonResponse(ResponseHelper.channelPageResponse(request.getPathParameter("channelId"),
                         request.getQueryParameter("nextpage")), "public, max-age=3600");


### PR DESCRIPTION
Google uses URLs with `/channel` so it's better to keep it this way, for consistency.

See https://github.com/TeamPiped/Piped/pull/227 for the associated frontend changes