### PR TITLE
Make listening port configurable

### DIFF
--- a/src/main/java/me/kavin/piped/ServerLauncher.java
+++ b/src/main/java/me/kavin/piped/ServerLauncher.java
@@ -279,7 +279,7 @@ public class ServerLauncher extends MultithreadedHttpServerLauncher {
             Config config() {
                 return Config.create()
                         .with("http.listenAddresses",
-                                Config.ofValue(ofInetSocketAddress(), new InetSocketAddress(PORT)))
+                                Config.ofValue(ofInetSocketAddress(), new InetSocketAddress(Constants.PORT)))
                         .with("workers", Constants.HTTP_WORKERS);
             }
         };


### PR DESCRIPTION
The scoped `PORT` here is always `8080`. Therefore configuration `PORT` does not have any effect at all. This fixes that so the default port can be overriden.