### PR TITLE
Allow PubSub Hub url to be configured

### DIFF
--- a/src/main/java/me/kavin/piped/consts/Constants.java
+++ b/src/main/java/me/kavin/piped/consts/Constants.java
@@ -36,6 +36,8 @@ public class Constants {
     public static final String PUBLIC_URL;
 
     public static final String PUBSUB_URL;
+    
+    public static final String PUBSUB_HUB_URL;
 
     public static final String HTTP_PROXY;
 
@@ -85,6 +87,7 @@ public class Constants {
             CAPTCHA_API_KEY = getProperty(prop, "CAPTCHA_API_KEY");
             PUBLIC_URL = getProperty(prop, "API_URL");
             PUBSUB_URL = getProperty(prop, "PUBSUB_URL", PUBLIC_URL);
+            PUBSUB_HUB_URL = getProperty(prop, "PUBSUB_HUB_URL", "https://pubsubhubbub.appspot.com/subscribe");
             HTTP_PROXY = getProperty(prop, "HTTP_PROXY");
             FRONTEND_URL = getProperty(prop, "FRONTEND_URL", "https://piped.kavin.rocks");
             COMPROMISED_PASSWORD_CHECK = Boolean.parseBoolean(getProperty(prop, "COMPROMISED_PASSWORD_CHECK", "true"));

--- a/src/main/java/me/kavin/piped/utils/ResponseHelper.java
+++ b/src/main/java/me/kavin/piped/utils/ResponseHelper.java
@@ -1705,7 +1705,7 @@ public class ResponseHelper {
             String topic = "https://www.youtube.com/xml/feeds/videos.xml?channel_id=" + channelId;
 
             var builder = new Request.Builder()
-                    .url("https://pubsubhubbub.appspot.com/subscribe");
+                    .url(Constants.PUBSUB_HUB_URL);
 
             var formBuilder = new FormBody.Builder();
 


### PR DESCRIPTION
This will let users running Piped inaccessible from the public internet to self host their own WebSub / PubSubHubbub 0.4 compatible server to update their subscriptions feed.

Should help with TeamPiped/Piped#707 and TeamPiped/Piped#1130