### PR TITLE
fix the 'rename playlist' endpoint from api-test.sh

### DIFF
--- a/testing/api-test.sh
+++ b/testing/api-test.sh
@@ -124,7 +124,7 @@ curl ${CURLOPTS[@]} $HOST/user/playlists/add -X POST -H "Content-Type: applicati
 curl ${CURLOPTS[@]} $HOST/user/playlists/remove -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH_TOKEN" -d $(jq -n --compact-output --arg index "0" --arg playlistId $PLAYLIST_ID '{"index": $index, "playlistId": $playlistId}') || exit 1
 
 # Rename Playlist Test
-curl ${CURLOPTS[@]} $HOST/user/playlists/delete -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH_TOKEN" -d $(jq -n --compact-output --arg playlistId $PLAYLIST_ID --arg newName $RENAMED_PLAYLIST_NAME '{"playlistId": $playlistId, "newName": $newName}') || exit 1
+curl ${CURLOPTS[@]} $HOST/user/playlists/rename -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH_TOKEN" -d $(jq -n --compact-output --arg playlistId $PLAYLIST_ID --arg newName $RENAMED_PLAYLIST_NAME '{"playlistId": $playlistId, "newName": $newName}') || exit 1
 
 # Delete Playlist Test
 curl ${CURLOPTS[@]} $HOST/user/playlists/delete -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH_TOKEN" -d $(jq -n --compact-output --arg playlistId $PLAYLIST_ID '{"playlistId": $playlistId}') || exit 1


### PR DESCRIPTION
As I mentioned from my other PR, there is a typo in api-test.sh.