### PR TITLE
add visibility, license and tags to streams info

### DIFF
--- a/src/main/java/me/kavin/piped/utils/CollectionUtils.java
+++ b/src/main/java/me/kavin/piped/utils/CollectionUtils.java
@@ -4,7 +4,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import me.kavin.piped.utils.obj.*;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
-import org.schabi.newpipe.extractor.channel.ChannelTabInfo;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.linkhandler.ReadyChannelTabListLinkHandler;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
@@ -16,7 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-import static me.kavin.piped.consts.Constants.YOUTUBE_SERVICE;
 import static me.kavin.piped.utils.URLUtils.*;
 
 public class CollectionUtils {
@@ -71,7 +69,8 @@ public class CollectionUtils {
                 rewriteURL(info.getUploaderAvatarUrl()), rewriteURL(info.getThumbnailUrl()), info.getDuration(),
                 info.getViewCount(), info.getLikeCount(), info.getDislikeCount(), info.getUploaderSubscriberCount(), info.isUploaderVerified(),
                 audioStreams, videoStreams, relatedStreams, subtitles, livestream, rewriteVideoURL(info.getHlsUrl()),
-                rewriteVideoURL(info.getDashMpdUrl()), null, info.getCategory(), chapters, previewFrames);
+                rewriteVideoURL(info.getDashMpdUrl()), null, info.getCategory(), info.getLicence(),
+                info.getPrivacy().name().toLowerCase(), info.getTags(), chapters, previewFrames);
     }
 
     public static List<ContentItem> collectRelatedItems(List<? extends InfoItem> items) {

--- a/src/main/java/me/kavin/piped/utils/obj/Streams.java
+++ b/src/main/java/me/kavin/piped/utils/obj/Streams.java
@@ -9,7 +9,9 @@ import java.util.List;
 public class Streams {
 
     public String title, description, uploadDate, uploader, uploaderUrl, uploaderAvatar, thumbnailUrl, hls, dash,
-            lbryId, category;
+            lbryId, category, license, visibility;
+
+    public List<String> tags;
 
     public boolean uploaderVerified;
 
@@ -33,7 +35,7 @@ public class Streams {
                    String uploaderAvatar, String thumbnailUrl, long duration, long views, long likes, long dislikes, long uploaderSubscriberCount,
                    boolean uploaderVerified, List<PipedStream> audioStreams, List<PipedStream> videoStreams,
                    List<ContentItem> relatedStreams, List<Subtitle> subtitles, boolean livestream, String hls, String dash,
-                   String lbryId, String category, List<ChapterSegment> chapters, List<PreviewFrames> previewFrames) {
+                   String lbryId, String category, String license, String visibility, List<String> tags, List<ChapterSegment> chapters, List<PreviewFrames> previewFrames) {
         this.title = title;
         this.description = description;
         this.uploadDate = uploadDate;
@@ -58,5 +60,8 @@ public class Streams {
         this.chapters = chapters;
         this.previewFrames = previewFrames;
         this.category = category;
+        this.license = license;
+        this.tags = tags;
+        this.visibility = visibility;
     }
 }


### PR DESCRIPTION
They could all be well displayed in the description next to the category, so I think it makes sense to add them.
At least for LibreTube, the iso code for the video's language can be parsed to a translated string, that's why the language code would be useful as well in my eyes.