### PR TITLE
Check if authenticated before helping other instances for bypassing georestrictions

### DIFF
--- a/src/main/java/me/kavin/piped/utils/matrix/SyncRunner.java
+++ b/src/main/java/me/kavin/piped/utils/matrix/SyncRunner.java
@@ -129,7 +129,7 @@ public class SyncRunner implements Runnable {
                             var type = event.get("type").asText();
                             var content = event.at("/content/content");
 
-                            if (type.startsWith("video.piped.stream.bypass.")) {
+                            if (!UNAUTHENTICATED && type.startsWith("video.piped.stream.bypass.")) {
                                 switch (type) {
                                     case "video.piped.stream.bypass.request" -> {
                                         FederatedGeoBypassRequest bypassRequest = mapper.treeToValue(content, FederatedGeoBypassRequest.class);


### PR DESCRIPTION
We were previously wasting a lot of CPU on instances that don't have matrix auth configured.