### PR TITLE
Use extractor directly instead of StreamInfo for handling new videos

### DIFF
--- a/src/main/java/me/kavin/piped/utils/VideoHelpers.java
+++ b/src/main/java/me/kavin/piped/utils/VideoHelpers.java
@@ -6,6 +6,7 @@ import me.kavin.piped.consts.Constants;
 import me.kavin.piped.utils.obj.db.Video;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.StatelessSession;
+import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static me.kavin.piped.consts.Constants.YOUTUBE_SERVICE;
 import static org.schabi.newpipe.extractor.NewPipe.getPreferredContentCountry;
 import static org.schabi.newpipe.extractor.NewPipe.getPreferredLocalization;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonPostResponse;
@@ -22,7 +24,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 public class VideoHelpers {
     public static void handleNewVideo(String url, long time, me.kavin.piped.utils.obj.db.Channel channel) {
         try {
-            handleNewVideo(StreamInfo.getInfo(url), time, channel);
+            handleNewVideo(YOUTUBE_SERVICE.getStreamExtractor(url), time, channel);
         } catch (Exception e) {
             ExceptionHandler.handle(e);
         }


### PR DESCRIPTION
This should also reduce CPU usage, as we don't extract unnecessary information such as streams.