### PR TITLE
Update to Java 21 and use virtual threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: temurin
+          distribution: zulu
           cache: "gradle"
       - name: Run Build
         run: ./gradlew build

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -22,9 +22,9 @@ jobs:
           - testing/docker-compose.cockroachdb.yml
           - testing/docker-compose.yugabytedb.yml
         dockerfile:
-          - Dockerfile.ci
+          #- Dockerfile.ci
           - Dockerfile.azul.ci
-          - Dockerfile.openj9.ci
+          #- Dockerfile.openj9.ci
           - Dockerfile.graalvm-jvm.ci
         include:
           - sleep: 20

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: 1337kavin/piped:openj9
-            dockerfile: ./Dockerfile.openj9.ci
-          - image: 1337kavin/piped:hotspot
-            dockerfile: ./Dockerfile.ci
+#          - image: 1337kavin/piped:openj9
+#            dockerfile: ./Dockerfile.openj9.ci
+#          - image: 1337kavin/piped:hotspot
+#            dockerfile: ./Dockerfile.ci
           - image: 1337kavin/piped:latest,1337kavin/piped:azul-zulu
             dockerfile: ./Dockerfile.azul.ci
           - image: 1337kavin/piped:graalvm-jvm

--- a/.github/workflows/docker-migrations-build-test.yml
+++ b/.github/workflows/docker-migrations-build-test.yml
@@ -39,7 +39,7 @@ jobs:
           - testing/docker-compose.cockroachdb.yml
           - testing/docker-compose.yugabytedb.yml
         dockerfile:
-          - Dockerfile.ci
+          - Dockerfile.azul.ci
         include:
           - sleep: 20
           - docker-compose-file: testing/docker-compose.cockroachdb.yml

--- a/.github/workflows/docker-migrations-build-test.yml
+++ b/.github/workflows/docker-migrations-build-test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: temurin
+          distribution: zulu
           cache: "gradle"
       - name: Run Build
         run: ./gradlew shadowJar

--- a/.github/workflows/docker-migrations-build-test.yml
+++ b/.github/workflows/docker-migrations-build-test.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: "gradle"
       - name: Run Build

--- a/.github/workflows/fat-build.yml
+++ b/.github/workflows/fat-build.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: "gradle"
       - name: Run Build

--- a/.github/workflows/fat-build.yml
+++ b/.github/workflows/fat-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: temurin
+          distribution: zulu
           cache: "gradle"
       - name: Run Build
         run: ./gradlew shadowJar

--- a/Dockerfile.graalvm-jvm
+++ b/Dockerfile.graalvm-jvm
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:latest as build
+FROM container-registry.oracle.com/graalvm/native-image:latest as build
 
 WORKDIR /app/
 

--- a/Dockerfile.graalvm-jvm.ci
+++ b/Dockerfile.graalvm-jvm.ci
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:latest as build
+FROM container-registry.oracle.com/graalvm/native-image:latest as build
 
 RUN jlink \
     --add-modules java.base,java.logging,java.sql,java.management,java.xml,java.naming,java.desktop,jdk.crypto.ec \

--- a/build.gradle
+++ b/build.gradle
@@ -60,5 +60,5 @@ jar {
 
 group = 'me.kavin.piped'
 version = '1.0'
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.github.johnrengelman.shadow" version "8.1.1"
     id "java"
-    id "io.freefair.lombok" version "8.4"
     id "eclipse"
 }
 
@@ -44,6 +43,8 @@ dependencies {
     implementation 'io.sentry:sentry:6.30.0'
     implementation 'rocks.kavin:reqwest4j:1.0.12'
     implementation 'io.minio:minio:8.5.6'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }
 
 shadowJar {

--- a/src/main/java/me/kavin/piped/Main.java
+++ b/src/main/java/me/kavin/piped/Main.java
@@ -53,11 +53,11 @@ public class Main {
             System.exit(1);
         }
 
-        Multithreading.runAsync(() -> new Thread(new SyncRunner(
+        Multithreading.runAsync(() ->  Thread.ofVirtual().start(new SyncRunner(
                 new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build(),
                 MATRIX_SERVER,
                 MatrixHelper.MATRIX_TOKEN)
-        ).start());
+        ));
 
         new Timer().scheduleAtFixedRate(new TimerTask() {
             @Override

--- a/src/main/java/me/kavin/piped/utils/Multithreading.java
+++ b/src/main/java/me/kavin/piped/utils/Multithreading.java
@@ -5,7 +5,7 @@ import java.util.function.Supplier;
 
 public class Multithreading {
 
-    private static final ExecutorService es = Executors.newCachedThreadPool();
+    private static final ExecutorService es = Executors.newVirtualThreadPerTaskExecutor();
     private static final ExecutorService esLimited = Executors
             .newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 8);
     private static final ExecutorService esLimitedPubSub = Executors


### PR DESCRIPTION
This should significantly improve Piped's performance when handling a lot of tasks.

Draft since Java 21 just released today, and we need to wait for temurin, OpenJ9 for Java 21, and an ibm-semeru-runtimes container release.

Currently, only GraalVM and Zulu have released Java 21 container images.