### PR TITLE
feat(comments): add creator reply field

### DIFF
--- a/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java
+++ b/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java
@@ -344,7 +344,7 @@ public class StreamHandlers {
                 comments.add(new Comment(comment.getUploaderName(), getLastThumbnail(comment.getUploaderAvatars()),
                         comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::getContent).orElse(null), comment.getTextualUploadDate(),
                         substringYouTube(comment.getUploaderUrl()), repliespage, comment.getLikeCount(), comment.getReplyCount(),
-                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified()));
+                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply()));
             } catch (JsonProcessingException e) {
                 ExceptionHandler.handle(e);
             }
@@ -382,7 +382,7 @@ public class StreamHandlers {
                 comments.add(new Comment(comment.getUploaderName(), getLastThumbnail(comment.getUploaderAvatars()),
                         comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::getContent).orElse(null), comment.getTextualUploadDate(),
                         substringYouTube(comment.getUploaderUrl()), repliespage, comment.getLikeCount(), comment.getReplyCount(),
-                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified()));
+                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply()));
             } catch (JsonProcessingException e) {
                 ExceptionHandler.handle(e);
             }

--- a/src/main/java/me/kavin/piped/utils/obj/Comment.java
+++ b/src/main/java/me/kavin/piped/utils/obj/Comment.java
@@ -4,10 +4,10 @@ public class Comment {
 
     public String author, thumbnail, commentId, commentText, commentedTime, commentorUrl, repliesPage;
     public int likeCount, replyCount;
-    public boolean hearted, pinned, verified;
+    public boolean hearted, pinned, verified, creatorReplied;
 
     public Comment(String author, String thumbnail, String commentId, String commentText, String commentedTime,
-                   String commentorUrl, String repliesPage, int likeCount, int replyCount, boolean hearted, boolean pinned, boolean verified) {
+                   String commentorUrl, String repliesPage, int likeCount, int replyCount, boolean hearted, boolean pinned, boolean verified, boolean creatorReplied) {
         this.author = author;
         this.thumbnail = thumbnail;
         this.commentId = commentId;
@@ -20,5 +20,6 @@ public class Comment {
         this.hearted = hearted;
         this.pinned = pinned;
         this.verified = verified;
+        this.creatorReplied = creatorReplied;
     }
 }


### PR DESCRIPTION
Adds support for a new API field when the video creator has replied to a comment. For example, YouTube will show it as the creator's profile picture next to the number of comments.

Builds on https://github.com/TeamNewPipe/NewPipeExtractor/pull/1111 and is marked as a draft until a new release of NewPipeExtractor includes it. 
The changes are also currently untested, I will test (and update if necessary) as soon as a new version is released.

![YouTube comment with an answer and the creator's thumbnail next to it](https://github.com/TeamPiped/Piped-Backend/assets/63370021/cd971213-388e-4536-8dd8-060d4989dbc9)
