### PR TITLE
feat(comments): add isChannelOwner field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'it.unimi.dsi:fastutil-core:8.5.12'
     implementation 'commons-codec:commons-codec:1.16.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
-    implementation 'com.github.FireMasterK.NewPipeExtractor:NewPipeExtractor:48beff184a9792c4787cfa05fce577c3adf89f56'
+    implementation 'com.github.FireMasterK.NewPipeExtractor:NewPipeExtractor:8cf9a4aef0919df2ef1baafd30ab5bfefefc0844'
     implementation 'com.github.FireMasterK:nanojson:9f4af3b739cc13f3d0d9d4b758bbe2b2ae7119d7'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'

--- a/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java
+++ b/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java
@@ -344,7 +344,7 @@ public class StreamHandlers {
                 comments.add(new Comment(comment.getUploaderName(), getLastThumbnail(comment.getUploaderAvatars()),
                         comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::getContent).orElse(null), comment.getTextualUploadDate(),
                         substringYouTube(comment.getUploaderUrl()), repliespage, comment.getLikeCount(), comment.getReplyCount(),
-                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply()));
+                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply(), comment.isChannelOwner()));
             } catch (JsonProcessingException e) {
                 ExceptionHandler.handle(e);
             }
@@ -382,7 +382,7 @@ public class StreamHandlers {
                 comments.add(new Comment(comment.getUploaderName(), getLastThumbnail(comment.getUploaderAvatars()),
                         comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::getContent).orElse(null), comment.getTextualUploadDate(),
                         substringYouTube(comment.getUploaderUrl()), repliespage, comment.getLikeCount(), comment.getReplyCount(),
-                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply()));
+                        comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply(), comment.isChannelOwner()));
             } catch (JsonProcessingException e) {
                 ExceptionHandler.handle(e);
             }

--- a/src/main/java/me/kavin/piped/utils/obj/Comment.java
+++ b/src/main/java/me/kavin/piped/utils/obj/Comment.java
@@ -4,10 +4,10 @@ public class Comment {
 
     public String author, thumbnail, commentId, commentText, commentedTime, commentorUrl, repliesPage;
     public int likeCount, replyCount;
-    public boolean hearted, pinned, verified, creatorReplied;
+    public boolean hearted, pinned, verified, creatorReplied, channelOwner;
 
     public Comment(String author, String thumbnail, String commentId, String commentText, String commentedTime,
-                   String commentorUrl, String repliesPage, int likeCount, int replyCount, boolean hearted, boolean pinned, boolean verified, boolean creatorReplied) {
+                   String commentorUrl, String repliesPage, int likeCount, int replyCount, boolean hearted, boolean pinned, boolean verified, boolean creatorReplied, boolean channelOwner) {
         this.author = author;
         this.thumbnail = thumbnail;
         this.commentId = commentId;
@@ -21,5 +21,6 @@ public class Comment {
         this.pinned = pinned;
         this.verified = verified;
         this.creatorReplied = creatorReplied;
+        this.channelOwner = channelOwner;
     }
 }


### PR DESCRIPTION
Adds support for a new API field, if the comment was made by the channel owner. This can be used to highlight comments made by the creator, as for example YouTube and PeerTube do.

Requires a new version of NewPipeExtractor with https://github.com/TeamNewPipe/NewPipeExtractor/pull/1114 merged.
![Highlighted Name of a YouTube comment](https://github.com/TeamPiped/Piped-Backend/assets/63370021/c8c4e4dc-dc73-456e-87cd-b503a6ce0ed9)
