### PR TITLE
feat(sponsorblock): support actionTypes

### DIFF
--- a/src/main/java/me/kavin/piped/server/ServerLauncher.java
+++ b/src/main/java/me/kavin/piped/server/ServerLauncher.java
@@ -99,7 +99,7 @@ public class ServerLauncher extends MultithreadedHttpServerLauncher {
                     try {
                         return getJsonResponse(
                                 SponsorBlockUtils.getSponsors(request.getPathParameter("videoId"),
-                                        request.getQueryParameter("category")).getBytes(UTF_8),
+                                        request.getQueryParameter("category"), request.getQueryParameter("actionType")).getBytes(UTF_8),
                                 "public, max-age=3600");
                     } catch (Exception e) {
                         return getErrorResponse(e, request.getPath());

--- a/src/main/java/me/kavin/piped/utils/SponsorBlockUtils.java
+++ b/src/main/java/me/kavin/piped/utils/SponsorBlockUtils.java
@@ -22,7 +22,7 @@ import static me.kavin.piped.consts.Constants.mapper;
 
 public class SponsorBlockUtils {
 
-    public static String getSponsors(String id, String categories)
+    public static String getSponsors(String id, String categories, String actionType)
             throws IOException {
 
         if (StringUtils.isEmpty(categories))
@@ -34,7 +34,7 @@ public class SponsorBlockUtils {
             try {
 
                 var resp = RequestUtils.sendGetRaw(url + "/api/skipSegments/" + URLUtils.silentEncode(hash.substring(0, 4))
-                        + "?categories=" + URLUtils.silentEncode(categories)).get();
+                        + "?categories=" + URLUtils.silentEncode(categories) + "&actionTypes=" + URLUtils.silentEncode(actionType)).get();
 
                 if (resp.status() == 200) {
                     var any = mapper.readTree(resp.body());

--- a/src/main/java/me/kavin/piped/utils/SponsorBlockUtils.java
+++ b/src/main/java/me/kavin/piped/utils/SponsorBlockUtils.java
@@ -30,11 +30,14 @@ public class SponsorBlockUtils {
 
         String hash = DigestUtils.sha256Hex(id);
 
-        for (String url : Constants.SPONSORBLOCK_SERVERS) {
+        for (String apiUrl : Constants.SPONSORBLOCK_SERVERS) {
             try {
+                String url =apiUrl + "/api/skipSegments/" + URLUtils.silentEncode(hash.substring(0, 4))
+                        + "?categories=" + URLUtils.silentEncode(categories);
+                if (actionType != null && !actionType.isBlank())
+                    url += "&actionTypes=" + URLUtils.silentEncode(actionType);
 
-                var resp = RequestUtils.sendGetRaw(url + "/api/skipSegments/" + URLUtils.silentEncode(hash.substring(0, 4))
-                        + "?categories=" + URLUtils.silentEncode(categories) + "&actionTypes=" + URLUtils.silentEncode(actionType)).get();
+                var resp = RequestUtils.sendGetRaw(url).get();
 
                 if (resp.status() == 200) {
                     var any = mapper.readTree(resp.body());

--- a/src/main/java/me/kavin/piped/utils/SponsorBlockUtils.java
+++ b/src/main/java/me/kavin/piped/utils/SponsorBlockUtils.java
@@ -32,7 +32,8 @@ public class SponsorBlockUtils {
 
         for (String apiUrl : Constants.SPONSORBLOCK_SERVERS) {
             try {
-                String url =apiUrl + "/api/skipSegments/" + URLUtils.silentEncode(hash.substring(0, 4))
+                String url = apiUrl + "/api/skipSegments/" + URLUtils.silentEncode(hash.substring(0, 4))
+
                         + "?categories=" + URLUtils.silentEncode(categories);
                 if (actionType != null && !actionType.isBlank())
                     url += "&actionTypes=" + URLUtils.silentEncode(actionType);


### PR DESCRIPTION
Adds support for requesting different `actionType`s when requesting SponsorBlock segments.