### PR TITLE
fix: config location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         ports:
             - "127.0.0.1:8080:8080"
         volumes:
-            - ./config.properties:/app/config.properties
+            - ./config.properties:/config.properties
         depends_on:
             - postgres
     postgres:


### PR DESCRIPTION
`/app/config.properties` should be located at `/config.properties`, hotspot-entrypoint.sh does not cd into `/app` so the config is not being loaded