### PR TITLE
Sort audio bitrates to prevent low quality audio

### DIFF
--- a/src/main/java/me/kavin/piped/utils/CollectionUtils.java
+++ b/src/main/java/me/kavin/piped/utils/CollectionUtils.java
@@ -11,6 +11,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -73,6 +74,8 @@ public class CollectionUtils {
         info.getMetaInfo().forEach(metaInfoItem -> metaInfo.add(new MetaInfo(metaInfoItem.getTitle(), metaInfoItem.getContent().getContent(),
                 metaInfoItem.getUrls(), metaInfoItem.getUrlTexts()
         )));
+
+        audioStreams.sort(Comparator.comparingInt((PipedStream stream) -> stream.bitrate).reversed());
 
         return new Streams(info.getName(), info.getDescription().getContent(),
                 info.getTextualUploadDate(), info.getUploaderName(), substringYouTube(info.getUploaderUrl()),


### PR DESCRIPTION
When a user selects a video resolution manually (not from preferences), the player seems to select the first matching variant track. That typically means that selecting e.g. 2160p results in 40kbps audio, instead of 135kbps. This change sorts audio bitrates in the backend so that the highest qualities are first to avoid low quality audio.

This is a hack, not a proper fix, but I know Java and I don't know Vue or JS. Presumably there's some way to make the frontend select the higher quality audio.

Note that if a user prefers qualities below 480p I think they will now have high-quality audio, instead of low quality, which is a change from present. Relevant code:

https://github.com/TeamPiped/Piped/blob/40314cd0f0bdc6563cf65090fc4e5c431f956b8b/src/components/VideoPlayer.vue#L571-L576

Since audio bitrates are now sorted, default audio is HQ instead of LQ.

Should fix https://github.com/TeamPiped/Piped/issues/1441