### PR TITLE
Revert "chore(deps): update eclipse-temurin docker tag"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.2_13-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 
 WORKDIR /app/
 
@@ -7,7 +7,7 @@ COPY . /app/
 RUN --mount=type=cache,target=/root/.gradle/caches/ \
  ./gradlew shadowJar
 
-FROM eclipse-temurin:21.0.2_13-jre
+FROM eclipse-temurin:21-jre
 
 RUN --mount=type=cache,target=/var/cache/apt/ \
  apt-get update && \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.2_13-jre
+FROM eclipse-temurin:21-jre
 
 RUN --mount=type=cache,target=/var/cache/apt/ \
  apt-get update && \


### PR DESCRIPTION
Reverts TeamPiped/Piped-Backend#744

We want to use the latest tag, there's no need to pin JVM versions.