### PR TITLE
Allow for valid hibernate environment variables

### DIFF
--- a/src/main/java/me/kavin/piped/consts/Constants.java
+++ b/src/main/java/me/kavin/piped/consts/Constants.java
@@ -164,8 +164,9 @@ public class Constants {
                 S3_CLIENT = null;
             }
             System.getenv().forEach((key, value) -> {
-                if (key.startsWith("hibernate"))
-                    hibernateProperties.put(key, value);
+                if (key.startsWith("HIBERNATE"))
+                    String k = key.replace("_", ".").toLowerCase();
+                    hibernateProperties.put(k, value);
             });
             MATRIX_SERVER = getProperty(prop, "MATRIX_SERVER", "https://matrix-client.matrix.org");
             MATRIX_TOKEN = getProperty(prop, "MATRIX_TOKEN");


### PR DESCRIPTION
*nix systems can't have periods in their environment variable names, so we instead look for `HIBERNATE` prefixes, then lowercase and translate underscores to periods. This will allow for better compatibility with *nix systems when configuring likely sensitive hibernate values.