### PR TITLE
fix(ci): remove stream check as being flagged as bot

### DIFF
--- a/testing/api-test.sh
+++ b/testing/api-test.sh
@@ -36,12 +36,6 @@ curl "${CURLOPTS[@]}" $HOST/nextpage/playlists/PLQSoWXSpjA3-egtFq45DcUydZ885W7MT
 # Clips
 curl "${CURLOPTS[@]}" $HOST/clips/Ugkx71jS31nwsms_Cc65oi7yXF1mILflhhrO || exit 1
 
-# Streams
-curl "${CURLOPTS[@]}" $HOST/streams/BtN-goy9VOY || exit 1
-
-# Streams with meta info
-curl "${CURLOPTS[@]}" $HOST/streams/cJ9to6EmElQ || exit 1
-
 # Comments
 curl "${CURLOPTS[@]}" $HOST/comments/BtN-goy9VOY || exit 1
 


### PR DESCRIPTION
Removing the `stream` path checks from `api-test` script as it is flagged as bot traffic.