### PR TITLE
Update NewPipeExtractor to v0.26.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'it.unimi.dsi:fastutil-core:8.5.16'
     implementation 'commons-codec:commons-codec:1.19.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.81'
-    implementation 'com.github.FireMasterK:NewPipeExtractor:92809cedefd89ce68bc4de8763e9d5f2760f5899'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.26.0'
     implementation 'com.github.FireMasterK:nanojson:a507525e549a836c3a8b6ab7090dca38e92942ef'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.19.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.19.2'


### PR DESCRIPTION
Update NewPipeExtractor to its latest official release.
Fixes recent issues of videos not loading at all.