### PR TITLE
Add an alternative way for updating feeds for closed off instances

### DIFF
--- a/src/main/java/me/kavin/piped/Main.java
+++ b/src/main/java/me/kavin/piped/Main.java
@@ -18,6 +18,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerManager;
@@ -256,6 +257,54 @@ public class Main {
                 }
             }
         }, 0, TimeUnit.MINUTES.toMillis(60));
+
+        if (Constants.FEED_REFRESH)
+            Thread.ofVirtual().name("feed-refresh").start(() -> {
+                while (true) {
+                    try {
+                        List<String> channelIds;
+                        try (StatelessSession s = DatabaseSessionFactory.createStatelessSession()) {
+                            channelIds = s.createNativeQuery("SELECT DISTINCT channel FROM users_subscribed", String.class)
+                                    .stream()
+                                    .filter(Objects::nonNull)
+                                    .distinct()
+                                    .collect(Collectors.toCollection(ObjectArrayList::new));
+                        }
+
+                        long periodMs = TimeUnit.MINUTES.toMillis(Constants.FEED_REFRESH_MINUTES);
+                        long delay = channelIds.isEmpty() ? periodMs : Math.max(1, periodMs / channelIds.size());
+
+                        System.out.println("FeedRefresh: " + channelIds.size() + " channels, one every " + delay + "ms");
+
+                        for (String channelId : channelIds) {
+                            try {
+                                var info = ChannelInfo.getInfo("https://youtube.com/channel/" + channelId);
+                                var tabInfo = ChannelHelpers.videosTabInfo(info);
+                                if (tabInfo != null)
+                                    Multithreading.runAsync(() -> ChannelHelpers.federateChannelVideos(tabInfo));
+                                Multithreading.runAsync(() -> ChannelHelpers.federateChannelInfo(info));
+                                if (tabInfo != null)
+                                    ChannelHelpers.updateChannelVideos(info, tabInfo);
+                            } catch (Exception e) {
+                                ExceptionHandler.handle(e);
+                            }
+                            Thread.sleep(delay);
+                        }
+
+                        if (channelIds.isEmpty())
+                            Thread.sleep(periodMs);
+                    } catch (InterruptedException e) {
+                        break;
+                    } catch (Exception e) {
+                        ExceptionHandler.handle(e);
+                        try {
+                            Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+                        } catch (InterruptedException ie) {
+                            break;
+                        }
+                    }
+                }
+            });
 
     }
 }

--- a/src/main/java/me/kavin/piped/Main.java
+++ b/src/main/java/me/kavin/piped/Main.java
@@ -122,7 +122,7 @@ public class Main {
         if (Constants.DISABLE_TIMERS)
             return;
 
-        new Timer().scheduleAtFixedRate(new TimerTask() {
+        if (!Constants.DISABLE_PUBSUB) new Timer().scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
                 try (StatelessSession s = DatabaseSessionFactory.createStatelessSession()) {
@@ -181,7 +181,7 @@ public class Main {
             }
         }, 0, TimeUnit.MINUTES.toMillis(90));
 
-        new Timer().scheduleAtFixedRate(new TimerTask() {
+        if (!Constants.DISABLE_PUBSUB) new Timer().scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
                 try (StatelessSession s = DatabaseSessionFactory.createStatelessSession()) {

--- a/src/main/java/me/kavin/piped/consts/Constants.java
+++ b/src/main/java/me/kavin/piped/consts/Constants.java
@@ -66,6 +66,8 @@ public class Constants {
 
     public static final boolean DISABLE_TIMERS;
 
+    public static final boolean DISABLE_PUBSUB;
+
     public static final String RYD_PROXY_URL;
 
     public static final List<String> SPONSORBLOCK_SERVERS;
@@ -144,6 +146,7 @@ public class Constants {
             DISABLE_REGISTRATION = Boolean.parseBoolean(getProperty(prop, "DISABLE_REGISTRATION", "false"));
             FEED_RETENTION = Integer.parseInt(getProperty(prop, "FEED_RETENTION", "30"));
             DISABLE_TIMERS = Boolean.parseBoolean(getProperty(prop, "DISABLE_TIMERS", "false"));
+            DISABLE_PUBSUB = Boolean.parseBoolean(getProperty(prop, "DISABLE_PUBSUB", "false"));
             RYD_PROXY_URL = getProperty(prop, "RYD_PROXY_URL", "https://ryd-proxy.kavin.rocks");
             SPONSORBLOCK_SERVERS = List.of(getProperty(prop, "SPONSORBLOCK_SERVERS", "https://sponsor.ajay.app,https://sponsorblock.kavin.rocks")
                     .split(","));

--- a/src/main/java/me/kavin/piped/consts/Constants.java
+++ b/src/main/java/me/kavin/piped/consts/Constants.java
@@ -68,6 +68,10 @@ public class Constants {
 
     public static final boolean DISABLE_PUBSUB;
 
+    public static final boolean FEED_REFRESH;
+
+    public static final int FEED_REFRESH_MINUTES;
+
     public static final String RYD_PROXY_URL;
 
     public static final List<String> SPONSORBLOCK_SERVERS;
@@ -147,6 +151,8 @@ public class Constants {
             FEED_RETENTION = Integer.parseInt(getProperty(prop, "FEED_RETENTION", "30"));
             DISABLE_TIMERS = Boolean.parseBoolean(getProperty(prop, "DISABLE_TIMERS", "false"));
             DISABLE_PUBSUB = Boolean.parseBoolean(getProperty(prop, "DISABLE_PUBSUB", "false"));
+            FEED_REFRESH = Boolean.parseBoolean(getProperty(prop, "FEED_REFRESH", "false"));
+            FEED_REFRESH_MINUTES = Integer.parseInt(getProperty(prop, "FEED_REFRESH_MINUTES", "15"));
             RYD_PROXY_URL = getProperty(prop, "RYD_PROXY_URL", "https://ryd-proxy.kavin.rocks");
             SPONSORBLOCK_SERVERS = List.of(getProperty(prop, "SPONSORBLOCK_SERVERS", "https://sponsor.ajay.app,https://sponsorblock.kavin.rocks")
                     .split(","));

--- a/src/main/java/me/kavin/piped/server/handlers/ChannelHandlers.java
+++ b/src/main/java/me/kavin/piped/server/handlers/ChannelHandlers.java
@@ -41,106 +41,17 @@ public class ChannelHandlers {
 
         final ChannelInfo info = ChannelInfo.getInfo("https://youtube.com/" + channelPath);
 
-        final var preloadedVideosTab = collectPreloadedTabs(info.getTabs())
-                .stream()
-                .filter(tab -> tab.getContentFilters().contains(ChannelTabs.VIDEOS))
-                .findFirst();
-
-        final ChannelTabInfo tabInfo = preloadedVideosTab.isPresent() ?
-                ChannelTabInfo.getInfo(YOUTUBE_SERVICE, preloadedVideosTab.get()) :
-                null;
+        final ChannelTabInfo tabInfo = ChannelHelpers.videosTabInfo(info);
 
         final List<ContentItem> relatedStreams = tabInfo != null ? collectRelatedItems(tabInfo.getRelatedItems()) : List.of();
 
         if (tabInfo != null)
-            Multithreading.runAsync(() -> tabInfo.getRelatedItems()
-                    .stream().filter(StreamInfoItem.class::isInstance)
-                    .map(StreamInfoItem.class::cast)
-                    .forEach(infoItem -> {
-                        if (
-                                infoItem.getUploadDate() != null &&
-                                        System.currentTimeMillis() - infoItem.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
-                                                < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION)
-                        )
-                            try {
-                                MatrixHelper.sendEvent("video.piped.stream.info", new FederatedVideoInfo(
-                                        StringUtils.substring(infoItem.getUrl(), -11), StringUtils.substring(infoItem.getUploaderUrl(), -24),
-                                        infoItem.getName(),
-                                        infoItem.getDuration(), infoItem.getViewCount())
-                                );
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                    })
-            );
+            Multithreading.runAsync(() -> ChannelHelpers.federateChannelVideos(tabInfo));
 
-        Multithreading.runAsync(() -> {
-            try {
-                MatrixHelper.sendEvent("video.piped.channel.info", new FederatedChannelInfo(
-                        info.getId(), StringUtils.abbreviate(info.getName(), 100), info.getAvatars().isEmpty() ? null : info.getAvatars().getLast().getUrl(), info.isVerified())
-                );
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        Multithreading.runAsync(() -> ChannelHelpers.federateChannelInfo(info));
 
         if (tabInfo != null)
-            Multithreading.runAsync(() -> {
-
-                var channel = DatabaseHelper.getChannelFromId(info.getId());
-
-                try (StatelessSession s = DatabaseSessionFactory.createStatelessSession()) {
-
-                    if (channel != null) {
-
-                        ChannelHelpers.updateChannel(s, channel, StringUtils.abbreviate(info.getName(), 100), info.getAvatars().isEmpty() ? null : info.getAvatars().getLast().getUrl(), info.isVerified());
-
-                        Set<String> ids = tabInfo.getRelatedItems()
-                                .stream()
-                                .filter(StreamInfoItem.class::isInstance)
-                                .map(StreamInfoItem.class::cast)
-                                .filter(item -> {
-                                    long time = item.getUploadDate() != null
-                                            ? item.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
-                                            : System.currentTimeMillis();
-                                    return System.currentTimeMillis() - time < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION);
-                                })
-                                .map(item -> {
-                                    try {
-                                        return YOUTUBE_SERVICE.getStreamLHFactory().getId(item.getUrl());
-                                    } catch (ParsingException e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                })
-                                .collect(Collectors.toUnmodifiableSet());
-
-                        List<Video> videos = DatabaseHelper.getVideosFromIds(s, ids);
-
-                        tabInfo.getRelatedItems()
-                                .stream()
-                                .filter(StreamInfoItem.class::isInstance)
-                                .map(StreamInfoItem.class::cast).forEach(item -> {
-                                    long time = item.getUploadDate() != null
-                                            ? item.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
-                                            : System.currentTimeMillis();
-                                    if (System.currentTimeMillis() - time < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION))
-                                        try {
-                                            String id = YOUTUBE_SERVICE.getStreamLHFactory().getId(item.getUrl());
-                                            var video = videos.stream()
-                                                    .filter(v -> v.getId().equals(id))
-                                                    .findFirst();
-                                            if (video.isPresent()) {
-                                                VideoHelpers.updateVideo(id, item);
-                                            } else {
-                                                VideoHelpers.handleNewVideo("https://youtube.com/watch?v=" + id, time, channel);
-                                            }
-                                        } catch (Exception e) {
-                                            ExceptionHandler.handle(e);
-                                        }
-                                });
-                    }
-                }
-            });
+            Multithreading.runAsync(() -> ChannelHelpers.updateChannelVideos(info, tabInfo));
 
         String nextpage = null;
         if (tabInfo != null && tabInfo.hasNextPage()) {

--- a/src/main/java/me/kavin/piped/utils/ChannelHelpers.java
+++ b/src/main/java/me/kavin/piped/utils/ChannelHelpers.java
@@ -7,13 +7,22 @@ import com.rometools.modules.mediarss.types.PlayerReference;
 import com.rometools.modules.mediarss.types.Thumbnail;
 import com.rometools.rome.feed.synd.*;
 import me.kavin.piped.consts.Constants;
+import me.kavin.piped.utils.obj.MatrixHelper;
 import me.kavin.piped.utils.obj.db.Channel;
 import me.kavin.piped.utils.obj.db.Video;
+import me.kavin.piped.utils.obj.federation.FederatedChannelInfo;
+import me.kavin.piped.utils.obj.federation.FederatedVideoInfo;
 import okhttp3.Request;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.hibernate.StatelessSession;
+import org.schabi.newpipe.extractor.channel.ChannelInfo;
+import org.schabi.newpipe.extractor.channel.tabs.ChannelTabInfo;
+import org.schabi.newpipe.extractor.channel.tabs.ChannelTabs;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -22,7 +31,12 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import static me.kavin.piped.consts.Constants.YOUTUBE_SERVICE;
+import static me.kavin.piped.utils.CollectionUtils.collectPreloadedTabs;
 import static me.kavin.piped.utils.URLUtils.rewriteURL;
 
 public class ChannelHelpers {
@@ -72,6 +86,103 @@ public class ChannelHelpers {
             var tr = s.beginTransaction();
             s.update(channel);
             tr.commit();
+        }
+    }
+
+    public static void updateChannelVideos(ChannelInfo info, ChannelTabInfo tabInfo) {
+
+        var channel = DatabaseHelper.getChannelFromId(info.getId());
+
+        try (StatelessSession s = DatabaseSessionFactory.createStatelessSession()) {
+
+            if (channel != null) {
+
+                updateChannel(s, channel, StringUtils.abbreviate(info.getName(), 100), info.getAvatars().isEmpty() ? null : info.getAvatars().getLast().getUrl(), info.isVerified());
+
+                Set<String> ids = tabInfo.getRelatedItems()
+                        .stream()
+                        .filter(StreamInfoItem.class::isInstance)
+                        .map(StreamInfoItem.class::cast)
+                        .filter(item -> {
+                            long time = item.getUploadDate() != null
+                                    ? item.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
+                                    : System.currentTimeMillis();
+                            return System.currentTimeMillis() - time < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION);
+                        })
+                        .map(item -> {
+                            try {
+                                return YOUTUBE_SERVICE.getStreamLHFactory().getId(item.getUrl());
+                            } catch (ParsingException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .collect(Collectors.toUnmodifiableSet());
+
+                List<Video> videos = DatabaseHelper.getVideosFromIds(s, ids);
+
+                tabInfo.getRelatedItems()
+                        .stream()
+                        .filter(StreamInfoItem.class::isInstance)
+                        .map(StreamInfoItem.class::cast).forEach(item -> {
+                            long time = item.getUploadDate() != null
+                                    ? item.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
+                                    : System.currentTimeMillis();
+                            if (System.currentTimeMillis() - time < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION))
+                                try {
+                                    String id = YOUTUBE_SERVICE.getStreamLHFactory().getId(item.getUrl());
+                                    var video = videos.stream()
+                                            .filter(v -> v.getId().equals(id))
+                                            .findFirst();
+                                    if (video.isPresent()) {
+                                        VideoHelpers.updateVideo(id, item);
+                                    } else {
+                                        VideoHelpers.handleNewVideo("https://youtube.com/watch?v=" + id, time, channel);
+                                    }
+                                } catch (Exception e) {
+                                    ExceptionHandler.handle(e);
+                                }
+                        });
+            }
+        }
+    }
+
+    public static ChannelTabInfo videosTabInfo(ChannelInfo info) throws ExtractionException, IOException {
+        var preloadedVideosTab = collectPreloadedTabs(info.getTabs())
+                .stream()
+                .filter(tab -> tab.getContentFilters().contains(ChannelTabs.VIDEOS))
+                .findFirst();
+        return preloadedVideosTab.isPresent() ? ChannelTabInfo.getInfo(YOUTUBE_SERVICE, preloadedVideosTab.get()) : null;
+    }
+
+    public static void federateChannelVideos(ChannelTabInfo tabInfo) {
+        tabInfo.getRelatedItems()
+                .stream().filter(StreamInfoItem.class::isInstance)
+                .map(StreamInfoItem.class::cast)
+                .forEach(infoItem -> {
+                    if (
+                            infoItem.getUploadDate() != null &&
+                                    System.currentTimeMillis() - infoItem.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
+                                            < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION)
+                    )
+                        try {
+                            MatrixHelper.sendEvent("video.piped.stream.info", new FederatedVideoInfo(
+                                    StringUtils.substring(infoItem.getUrl(), -11), StringUtils.substring(infoItem.getUploaderUrl(), -24),
+                                    infoItem.getName(),
+                                    infoItem.getDuration(), infoItem.getViewCount())
+                            );
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                });
+    }
+
+    public static void federateChannelInfo(ChannelInfo info) {
+        try {
+            MatrixHelper.sendEvent("video.piped.channel.info", new FederatedChannelInfo(
+                    info.getId(), StringUtils.abbreviate(info.getName(), 100), info.getAvatars().isEmpty() ? null : info.getAvatars().getLast().getUrl(), info.isVerified())
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/me/kavin/piped/utils/DatabaseHelper.java
+++ b/src/main/java/me/kavin/piped/utils/DatabaseHelper.java
@@ -202,7 +202,7 @@ public class DatabaseHelper {
             ExceptionHandler.handle(e);
         }
 
-        Multithreading.runAsync(() -> {
+        if (!Constants.DISABLE_PUBSUB) Multithreading.runAsync(() -> {
             try {
                 PubSubHelper.subscribePubSub(channelId);
             } catch (IOException e) {


### PR DESCRIPTION
This PR is already active on docker here alongside other changes: logicalkarma/piped:latest.

This PR introduces 3 new env variables:
| Variable | Default | Description |
| --- | --- | --- |
| `DISABLE_PUBSUB` | `false` | Stop subscribing to YouTube's WebSub hub, so the backend no longer receives push notifications of new uploads from subscribed channels. |
| `FEED_REFRESH` | `false` | Enable a background job that periodically refreshes the videos of every subscribed channel, as an alternative to WebSub. |
| `FEED_REFRESH_MINUTES` | `15` | With `FEED_REFRESH` enabled, the window over which all subscribed channels are refreshed, evenly spaced. |

Each request is paced out to fit the refresh window. This is done to avoid bursts. The timing is only meant as a suggestion and assumes requests take 0 time for spacing.

The code in this PR was written with Claude Opus 4.8. It was human reviewed.

Relevant issues:
https://github.com/TeamPiped/Piped/issues/707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional background feed refresh worker that automatically updates subscribed channel data at configurable intervals when enabled.

* **Configuration**
  * Introduced new settings to disable PubSub updates and enable custom feed refresh scheduling with adjustable refresh intervals.

* **Refactor**
  * Improved channel update handling by consolidating related logic into reusable helper methods for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeamPiped/Piped-Backend/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->