### PR TITLE
feat(feeds): refresh shorts and livestreams in FEED_REFRESH, with per…

### DIFF
--- a/src/main/java/me/kavin/piped/Main.java
+++ b/src/main/java/me/kavin/piped/Main.java
@@ -279,12 +279,29 @@ public class Main {
                         for (String channelId : channelIds) {
                             try {
                                 var info = ChannelInfo.getInfo("https://youtube.com/channel/" + channelId);
-                                var tabInfo = ChannelHelpers.videosTabInfo(info);
-                                if (tabInfo != null)
-                                    Multithreading.runAsync(() -> ChannelHelpers.federateChannelVideos(tabInfo));
                                 Multithreading.runAsync(() -> ChannelHelpers.federateChannelInfo(info));
-                                if (tabInfo != null)
-                                    ChannelHelpers.updateChannelVideos(info, tabInfo);
+
+                                if (Constants.FEED_REFRESH_VIDEOS) {
+                                    try {
+                                        ChannelHelpers.refreshChannelTab(info, ChannelHelpers.videosTabInfo(info));
+                                    } catch (Exception e) {
+                                        ExceptionHandler.handle(e);
+                                    }
+                                }
+                                if (Constants.FEED_REFRESH_SHORTS) {
+                                    try {
+                                        ChannelHelpers.refreshChannelTab(info, ChannelHelpers.shortsTabInfo(info));
+                                    } catch (Exception e) {
+                                        ExceptionHandler.handle(e);
+                                    }
+                                }
+                                if (Constants.FEED_REFRESH_LIVESTREAMS) {
+                                    try {
+                                        ChannelHelpers.refreshChannelTab(info, ChannelHelpers.livestreamsTabInfo(info));
+                                    } catch (Exception e) {
+                                        ExceptionHandler.handle(e);
+                                    }
+                                }
                             } catch (Exception e) {
                                 ExceptionHandler.handle(e);
                             }

--- a/src/main/java/me/kavin/piped/consts/Constants.java
+++ b/src/main/java/me/kavin/piped/consts/Constants.java
@@ -72,6 +72,12 @@ public class Constants {
 
     public static final int FEED_REFRESH_MINUTES;
 
+    public static final boolean FEED_REFRESH_VIDEOS;
+
+    public static final boolean FEED_REFRESH_SHORTS;
+
+    public static final boolean FEED_REFRESH_LIVESTREAMS;
+
     public static final String RYD_PROXY_URL;
 
     public static final List<String> SPONSORBLOCK_SERVERS;
@@ -153,6 +159,9 @@ public class Constants {
             DISABLE_PUBSUB = Boolean.parseBoolean(getProperty(prop, "DISABLE_PUBSUB", "false"));
             FEED_REFRESH = Boolean.parseBoolean(getProperty(prop, "FEED_REFRESH", "false"));
             FEED_REFRESH_MINUTES = Integer.parseInt(getProperty(prop, "FEED_REFRESH_MINUTES", "15"));
+            FEED_REFRESH_VIDEOS = Boolean.parseBoolean(getProperty(prop, "FEED_REFRESH_VIDEOS", "true"));
+            FEED_REFRESH_SHORTS = Boolean.parseBoolean(getProperty(prop, "FEED_REFRESH_SHORTS", "true"));
+            FEED_REFRESH_LIVESTREAMS = Boolean.parseBoolean(getProperty(prop, "FEED_REFRESH_LIVESTREAMS", "true"));
             RYD_PROXY_URL = getProperty(prop, "RYD_PROXY_URL", "https://ryd-proxy.kavin.rocks");
             SPONSORBLOCK_SERVERS = List.of(getProperty(prop, "SPONSORBLOCK_SERVERS", "https://sponsor.ajay.app,https://sponsorblock.kavin.rocks")
                     .split(","));

--- a/src/main/java/me/kavin/piped/utils/ChannelHelpers.java
+++ b/src/main/java/me/kavin/piped/utils/ChannelHelpers.java
@@ -147,11 +147,29 @@ public class ChannelHelpers {
     }
 
     public static ChannelTabInfo videosTabInfo(ChannelInfo info) throws ExtractionException, IOException {
-        var preloadedVideosTab = collectPreloadedTabs(info.getTabs())
+        return tabInfo(info, ChannelTabs.VIDEOS);
+    }
+
+    public static ChannelTabInfo shortsTabInfo(ChannelInfo info) throws ExtractionException, IOException {
+        return tabInfo(info, ChannelTabs.SHORTS);
+    }
+
+    public static ChannelTabInfo livestreamsTabInfo(ChannelInfo info) throws ExtractionException, IOException {
+        return tabInfo(info, ChannelTabs.LIVESTREAMS);
+    }
+
+    private static ChannelTabInfo tabInfo(ChannelInfo info, String tabId) throws ExtractionException, IOException {
+        var tab = info.getTabs()
                 .stream()
-                .filter(tab -> tab.getContentFilters().contains(ChannelTabs.VIDEOS))
+                .filter(t -> t.getContentFilters().contains(tabId))
                 .findFirst();
-        return preloadedVideosTab.isPresent() ? ChannelTabInfo.getInfo(YOUTUBE_SERVICE, preloadedVideosTab.get()) : null;
+        return tab.isPresent() ? ChannelTabInfo.getInfo(YOUTUBE_SERVICE, tab.get()) : null;
+    }
+
+    public static void refreshChannelTab(ChannelInfo info, ChannelTabInfo tabInfo) {
+        if (tabInfo == null) return;
+        Multithreading.runAsync(() -> federateChannelVideos(tabInfo));
+        updateChannelVideos(info, tabInfo);
     }
 
     public static void federateChannelVideos(ChannelTabInfo tabInfo) {

--- a/src/main/java/me/kavin/piped/utils/ChannelHelpers.java
+++ b/src/main/java/me/kavin/piped/utils/ChannelHelpers.java
@@ -124,10 +124,11 @@ public class ChannelHelpers {
                         .stream()
                         .filter(StreamInfoItem.class::isInstance)
                         .map(StreamInfoItem.class::cast).forEach(item -> {
-                            long time = item.getUploadDate() != null
-                                    ? item.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
+                            var uploadDate = item.getUploadDate();
+                            long timeForRetention = uploadDate != null
+                                    ? uploadDate.offsetDateTime().toInstant().toEpochMilli()
                                     : System.currentTimeMillis();
-                            if (System.currentTimeMillis() - time < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION))
+                            if (System.currentTimeMillis() - timeForRetention < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION))
                                 try {
                                     String id = YOUTUBE_SERVICE.getStreamLHFactory().getId(item.getUrl());
                                     var video = videos.stream()
@@ -136,7 +137,8 @@ public class ChannelHelpers {
                                     if (video.isPresent()) {
                                         VideoHelpers.updateVideo(id, item);
                                     } else {
-                                        VideoHelpers.handleNewVideo("https://youtube.com/watch?v=" + id, time, channel);
+                                        VideoHelpers.handleNewVideo("https://youtube.com/watch?v=" + id,
+                                                uploadDate != null ? timeForRetention : -1L, channel);
                                     }
                                 } catch (Exception e) {
                                     ExceptionHandler.handle(e);

--- a/src/main/java/me/kavin/piped/utils/DatabaseHelper.java
+++ b/src/main/java/me/kavin/piped/utils/DatabaseHelper.java
@@ -226,11 +226,13 @@ public class DatabaseHelper {
                     .filter(StreamInfoItem.class::isInstance)
                     .map(StreamInfoItem.class::cast)
                     .forEach(item -> {
-                        long time = item.getUploadDate() != null
-                                ? item.getUploadDate().offsetDateTime().toInstant().toEpochMilli()
+                        var uploadDate = item.getUploadDate();
+                        long timeForRetention = uploadDate != null
+                                ? uploadDate.offsetDateTime().toInstant().toEpochMilli()
                                 : System.currentTimeMillis();
-                        if ((System.currentTimeMillis() - time) < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION))
-                            VideoHelpers.handleNewVideo(item.getUrl(), time, channel);
+                        if ((System.currentTimeMillis() - timeForRetention) < TimeUnit.DAYS.toMillis(Constants.FEED_RETENTION))
+                            VideoHelpers.handleNewVideo(item.getUrl(),
+                                    uploadDate != null ? timeForRetention : -1L, channel);
                     });
         });
 

--- a/src/main/java/me/kavin/piped/utils/VideoHelpers.java
+++ b/src/main/java/me/kavin/piped/utils/VideoHelpers.java
@@ -6,6 +6,7 @@ import me.kavin.piped.consts.Constants;
 import me.kavin.piped.utils.obj.db.Video;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.StatelessSession;
+import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -49,7 +50,7 @@ public class VideoHelpers {
                 if (!DatabaseHelper.doesVideoExist(s, info.getId())) {
 
                     Video video = new Video(info.getId(), info.getName(), info.getViewCount(), info.getDuration(),
-                            Math.max(infoTime, time), info.getThumbnails().getLast().getUrl(), info.isShortFormContent(), channel);
+                            pickUploaded(info.getUploadDate(), time), info.getThumbnails().getLast().getUrl(), info.isShortFormContent(), channel);
 
                     insertVideo(video);
                     return;
@@ -80,7 +81,7 @@ public class VideoHelpers {
                     boolean isShort = extractor.isShortFormContent() || isShort(extractor.getId());
 
                     Video video = new Video(extractor.getId(), extractor.getName(), extractor.getViewCount(), extractor.getLength(),
-                            Math.max(infoTime, time), extractor.getThumbnails().getLast().getUrl(), isShort, channel);
+                            pickUploaded(extractor.getUploadDate(), time), extractor.getThumbnails().getLast().getUrl(), isShort, channel);
 
                     insertVideo(video);
 
@@ -88,6 +89,18 @@ public class VideoHelpers {
             }
         }
 
+    }
+
+    private static long pickUploaded(DateWrapper extractorDate, long providedTime) {
+        Long fromExtractor = extractorDate != null
+                ? extractorDate.offsetDateTime().toInstant().toEpochMilli()
+                : null;
+        Long fromCaller = providedTime > 0 ? providedTime : null;
+
+        if (fromExtractor != null && fromCaller != null) return Math.max(fromExtractor, fromCaller);
+        if (fromExtractor != null) return fromExtractor;
+        if (fromCaller != null) return fromCaller;
+        return System.currentTimeMillis();
     }
 
     public static boolean isShort(String videoId) throws Exception {

--- a/src/main/java/me/kavin/piped/utils/matrix/SyncRunner.java
+++ b/src/main/java/me/kavin/piped/utils/matrix/SyncRunner.java
@@ -178,7 +178,7 @@ public class SyncRunner implements Runnable {
                                             var channel = DatabaseHelper.getChannelFromId(info.getUploaderId());
                                             if (channel != null)
                                                 VideoHelpers.handleNewVideo("https://www.youtube.com/watch?v=" + info.getVideoId(),
-                                                        System.currentTimeMillis(), channel);
+                                                        -1L, channel);
                                         }
 
                                     });


### PR DESCRIPTION
The FEED_REFRESH loop currently pulls only the videos tab of each subscribed channel; Shorts and livestream tabs are silently skipped. Surface them too and expose three independent boolean toggles so admins can disable any type to cut the YouTube requests issued per channel per cycle.

  FEED_REFRESH_VIDEOS       default true   pulls the videos tab
  FEED_REFRESH_SHORTS       default true   pulls the shorts tab
  FEED_REFRESH_LIVESTREAMS  default true   pulls the livestreams tab

FEED_REFRESH itself remains the master switch; when off, none of the new flags matter.

ChannelHelpers.videosTabInfo becomes a thin wrapper around a new private tabInfo(info, tabId) helper which the new shortsTabInfo and livestreamsTabInfo also use, keeping the tab-extraction logic in one place.

A new ChannelHelpers.refreshChannelTab(info, tabInfo) consolidates the federate-then-update pattern that the loop runs for each enabled tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel feed refreshes now support separate refreshing for **videos**, **shorts**, and **livestreams**.
  * Added configuration flags to independently enable/disable refreshing for each content type.
* **Bug Fixes**
  * Improved detection of the correct channel tabs by matching against tab content filters, with safe no-op behavior when a matching tab is missing.
  * Refreshes for videos/shorts/livestreams now run independently with dedicated error handling for more reliable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->