### PR TITLE
feat(feeds): add per-channel timeout to FEED_REFRESH loop

### DIFF
--- a/src/main/java/me/kavin/piped/Main.java
+++ b/src/main/java/me/kavin/piped/Main.java
@@ -31,7 +31,9 @@ import java.security.Security;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -278,15 +280,27 @@ public class Main {
 
                         for (String channelId : channelIds) {
                             try {
-                                var info = ChannelInfo.getInfo("https://youtube.com/channel/" + channelId);
-                                var tabInfo = ChannelHelpers.videosTabInfo(info);
-                                if (tabInfo != null)
-                                    Multithreading.runAsync(() -> ChannelHelpers.federateChannelVideos(tabInfo));
-                                Multithreading.runAsync(() -> ChannelHelpers.federateChannelInfo(info));
-                                if (tabInfo != null)
-                                    ChannelHelpers.updateChannelVideos(info, tabInfo);
-                            } catch (Exception e) {
-                                ExceptionHandler.handle(e);
+                                CompletableFuture.runAsync(() -> {
+                                    try {
+                                        var info = ChannelInfo.getInfo("https://youtube.com/channel/" + channelId);
+                                        var tabInfo = ChannelHelpers.videosTabInfo(info);
+                                        if (tabInfo != null)
+                                            Multithreading.runAsync(() -> ChannelHelpers.federateChannelVideos(tabInfo));
+                                        Multithreading.runAsync(() -> ChannelHelpers.federateChannelInfo(info));
+                                        if (tabInfo != null)
+                                            ChannelHelpers.updateChannelVideos(info, tabInfo);
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                }).get(60, TimeUnit.SECONDS);
+                            } catch (TimeoutException e) {
+                                System.out.println("FeedRefresh: timeout refreshing channel " + channelId + ", skipping");
+                            } catch (ExecutionException e) {
+                                var cause = e.getCause();
+                                ExceptionHandler.handle(cause instanceof Exception ex ? ex : e);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                break;
                             }
                             Thread.sleep(delay);
                         }


### PR DESCRIPTION
## Summary

- Wraps each channel refresh in the `FEED_REFRESH` loop with a `CompletableFuture` and a 60-second timeout
- `ChannelInfo.getInfo()` makes multiple HTTP calls per channel — even though the downloader has a 10s per-request timeout, the aggregate time for one channel can exceed that significantly
- A single hanging channel currently blocks the entire refresh loop indefinitely; with this change it gets skipped with a log message

## Context

PR #889 introduced the `FEED_REFRESH` periodic channel-refresh loop. The loop processes channels serially with paced delays, which is the right model for being a good citizen to YouTube's API. However, it has no per-channel time ceiling — if one channel's extraction hangs (network issues, YouTube serving unusual responses, etc.), the entire loop stalls.

This adds a lightweight safety net: each channel gets up to 60 seconds to complete, which is generous given the 10s HTTP timeout, but prevents indefinite blocking.

## Changes

- `Main.java`: Wrap per-channel refresh in `CompletableFuture.runAsync(...).get(60, TimeUnit.SECONDS)`
- On `TimeoutException`: log and skip to next channel
- On `ExecutionException`: unwrap cause and pass to existing `ExceptionHandler`
- On `InterruptedException`: restore interrupt flag and exit loop cleanly

## Test plan

- [ ] Build compiles cleanly (`./gradlew build`)
- [ ] Deploy with `FEED_REFRESH=true` and verify normal refresh cycle completes
- [ ] Verify timeout log message appears if a channel takes >60s (can be tested by temporarily lowering timeout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed refresh stability by limiting individual channel updates to a 60-second timeout.
  * Slow or stalled channels are now skipped instead of blocking the entire refresh process.
  * Refresh interruptions and failures are handled more gracefully, helping the app recover more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->