### PR TITLE
feat(feeds): add consecutive-failure backoff to FEED_REFRESH loop

### DIFF
--- a/src/main/java/me/kavin/piped/Main.java
+++ b/src/main/java/me/kavin/piped/Main.java
@@ -276,6 +276,8 @@ public class Main {
 
                         System.out.println("FeedRefresh: " + channelIds.size() + " channels, one every " + delay + "ms");
 
+                        int consecutiveFailures = 0;
+
                         for (String channelId : channelIds) {
                             try {
                                 var info = ChannelInfo.getInfo("https://youtube.com/channel/" + channelId);
@@ -285,8 +287,16 @@ public class Main {
                                 Multithreading.runAsync(() -> ChannelHelpers.federateChannelInfo(info));
                                 if (tabInfo != null)
                                     ChannelHelpers.updateChannelVideos(info, tabInfo);
+                                consecutiveFailures = 0;
                             } catch (Exception e) {
+                                consecutiveFailures++;
                                 ExceptionHandler.handle(e);
+                                if (consecutiveFailures >= 5) {
+                                    System.out.println("FeedRefresh: " + consecutiveFailures
+                                            + " consecutive failures, likely rate-limited — pausing 5 minutes");
+                                    Thread.sleep(TimeUnit.MINUTES.toMillis(5));
+                                    consecutiveFailures = 0;
+                                }
                             }
                             Thread.sleep(delay);
                         }


### PR DESCRIPTION
## Summary

- Adds a consecutive-failure counter to the `FEED_REFRESH` loop — after 5 failures in a row, pauses for 5 minutes before resuming
- Any successful channel refresh resets the counter to zero
- Prevents hammering YouTube when the instance is being rate-limited

## Problem

When YouTube rate-limits an instance (HTTP 429, CAPTCHA pages, or bot-detection), the current loop catches the error and immediately moves to the next channel with only the normal per-channel delay. With hundreds of subscribed channels, this means dozens of failed requests in quick succession against a service that is actively rejecting the instance.

## Why not exponential backoff?

The loop already has built-in per-channel pacing (`window / channel_count`), so a single fixed 5-minute pause is sufficient to let rate-limit windows expire. Exponential backoff adds state management complexity for marginal benefit in this architecture.

## Why not catch `ReCaptchaException` specifically?

The current `DownloaderImpl` does not throw `ReCaptchaException` on 429 responses — the CAPTCHA handling code is [commented out](https://github.com/TeamPiped/Piped-Backend/blob/master/src/main/java/me/kavin/piped/utils/DownloaderImpl.java#L44-L104). Rate-limiting manifests as `ParsingException` or `IOException` when the extractor fails to parse YouTube's error/CAPTCHA page. A type-agnostic consecutive-failure counter handles this correctly regardless of exception type.

## Changes

- `Main.java`: Add `consecutiveFailures` counter scoped to each refresh cycle
  - Reset to 0 on success
  - Increment on failure
  - If ≥ 5: log, pause 5 minutes, reset

## Test plan

- [ ] Build compiles cleanly (`./gradlew build`)
- [ ] Deploy with `FEED_REFRESH=true` and verify normal refresh cycle works (counter stays at 0)
- [ ] Simulate failures (e.g., disconnect network briefly) and verify backoff message appears after 5 consecutive failures
- [ ] Verify loop resumes normally after backoff pause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed refresh reliability by handling repeated update failures more gracefully.
  * After several consecutive failures, the app now pauses briefly before continuing, helping reduce rapid retry loops and temporary overload.
  * Successful channel updates reset the failure count so normal processing resumes smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->