### PR TITLE
Update NewPipeExtractor version to matching NewPipe app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,10 @@ dependencies {
     implementation 'it.unimi.dsi:fastutil-core:8.5.16'
     implementation 'commons-codec:commons-codec:1.19.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.81'
-    implementation 'com.github.FireMasterK:NewPipeExtractor:c83884eb5d2e9f077348acec3a2d9e9dc920ae91'
-    implementation 'com.github.FireMasterK:nanojson:a507525e549a836c3a8b6ab7090dca38e92942ef'
+    implementation('com.github.TeamNewPipe:NewPipeExtractor:01fdde08af40f39f5736c921303218209bc9c13e') {
+        exclude group: 'com.github.TeamNewPipe', module: 'nanojson'
+    }
+    implementation 'com.github.TeamNewPipe:nanojson:e9d656ddb49a412a5a0a5d5ef20ca7ef09549996'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.19.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.19.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.2'

--- a/src/main/java/me/kavin/piped/server/handlers/PlaylistHandlers.java
+++ b/src/main/java/me/kavin/piped/server/handlers/PlaylistHandlers.java
@@ -61,7 +61,7 @@ public class PlaylistHandlers {
         }
 
         final Playlist playlist = new Playlist(info.getName(), getLastThumbnail(info.getThumbnails()),
-                info.getDescription().getContent(), getLastThumbnail(info.getBanners()), nextpage,
+                info.getDescription().content(), getLastThumbnail(info.getBanners()), nextpage,
                 info.getUploaderName().isEmpty() ? null : info.getUploaderName(),
                 substringYouTube(info.getUploaderUrl()), getLastThumbnail(info.getUploaderAvatars()),
                 (int) info.getStreamCount(), relatedStreams);

--- a/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java
+++ b/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java
@@ -342,7 +342,7 @@ public class StreamHandlers {
                     repliespage = mapper.writeValueAsString(comment.getReplies());
 
                 comments.add(new Comment(comment.getUploaderName(), getLastThumbnail(comment.getUploaderAvatars()),
-                        comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::getContent).orElse(null), comment.getTextualUploadDate(),
+                        comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::content).orElse(null), comment.getTextualUploadDate(),
                         substringYouTube(comment.getUploaderUrl()), repliespage, comment.getLikeCount(), comment.getReplyCount(),
                         comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply(), comment.isChannelOwner()));
             } catch (JsonProcessingException e) {
@@ -380,7 +380,7 @@ public class StreamHandlers {
                     repliespage = mapper.writeValueAsString(comment.getReplies());
 
                 comments.add(new Comment(comment.getUploaderName(), getLastThumbnail(comment.getUploaderAvatars()),
-                        comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::getContent).orElse(null), comment.getTextualUploadDate(),
+                        comment.getCommentId(), Optional.ofNullable(comment.getCommentText()).map(Description::content).orElse(null), comment.getTextualUploadDate(),
                         substringYouTube(comment.getUploaderUrl()), repliespage, comment.getLikeCount(), comment.getReplyCount(),
                         comment.isHeartedByUploader(), comment.isPinned(), comment.isUploaderVerified(), comment.hasCreatorReply(), comment.isChannelOwner()));
             } catch (JsonProcessingException e) {

--- a/src/main/java/me/kavin/piped/utils/CollectionUtils.java
+++ b/src/main/java/me/kavin/piped/utils/CollectionUtils.java
@@ -71,11 +71,11 @@ public class CollectionUtils {
         final List<ContentItem> relatedStreams = collectRelatedItems(info.getRelatedItems());
 
         final List<MetaInfo> metaInfo = new ObjectArrayList<>();
-        info.getMetaInfo().forEach(metaInfoItem -> metaInfo.add(new MetaInfo(metaInfoItem.getTitle(), metaInfoItem.getContent().getContent(),
+        info.getMetaInfo().forEach(metaInfoItem -> metaInfo.add(new MetaInfo(metaInfoItem.getTitle(), metaInfoItem.getContent().content(),
                 metaInfoItem.getUrls(), metaInfoItem.getUrlTexts()
         )));
 
-        return new Streams(info.getName(), info.getDescription().getContent(),
+        return new Streams(info.getName(), info.getDescription().content(),
                 info.getTextualUploadDate(), info.getUploadDate() != null ? info.getUploadDate().offsetDateTime().toInstant().toEpochMilli() : -1,
                 info.getUploaderName(), substringYouTube(info.getUploaderUrl()), getLastThumbnail(info.getUploaderAvatars()),
                 getLastThumbnail(info.getThumbnails()), info.getDuration(), info.getViewCount(), info.getLikeCount(), info.getDislikeCount(),


### PR DESCRIPTION
Updated `NewPipeExtractor` and `nanojson` dependency to exactly match the Android NewPipe app `dev` branch (as of 2026-08-25).

The NewPipe app dependency is found here:
https://github.com/TeamNewPipe/NewPipe/blob/dev/gradle/libs.versions.toml

After updating, DASH video playback, related videos, and comments are completely working.

I will continuously update NewPipeExtractor to match the NewPipe app. So if NewPipe works, Piped will also work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated playlist descriptions, stream comments, and metadata handling to remain compatible with the latest content extraction APIs.
  * Improved dependency compatibility by aligning extractor components with updated TeamNewPipe versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->